### PR TITLE
Renames this version to of-rtm-6 and uses default bashrc file for setup

### DIFF
--- a/bin/foamEtcFile
+++ b/bin/foamEtcFile
@@ -54,14 +54,14 @@ options:
   -prefix <dir>     specify an alternative installation prefix
   -quiet            suppress all normal output
   -silent           suppress all stderr output
-  -version <ver>    specify an alternative OpenFOAM version
+  -version <ver>    specify an alternative of-rtm version
                     in the form Maj.Min.Rev (eg, 1.7.0)
   -help             print the usage
 
-Searches for OpenFOAM configuration files, that are generally found in the
+Searches for of-rtm configuration files, that are generally found in the
 installation "etc" directory, but can be located in the following locations,
 listed in order of precedence:
-- user level: \${HOME}/.OpenFOAM
+- user level: \${HOME}/.of-rtm
 - group level: \$FOAM_INST_DIR/site
 - other level: \$WM_PROJECT_DIR/etc
 
@@ -106,12 +106,12 @@ unset versionNum
 # handle standard and debian naming convention
 #
 case "$projectDirName" in
-OpenFOAM-*)         # standard naming convention OpenFOAM-<VERSION>
-    version="${projectDirName##OpenFOAM-}"
+of-rtm-*)         # standard naming convention of-rtm-<VERSION>
+    version="${projectDirName##of-rtm-}"
     ;;
 
-openfoam[0-9]* | openfoam-dev)     # debian naming convention 'openfoam<VERSION>'
-    versionNum="${projectDirName##openfoam}"
+of-rtm[0-9]* | of-rtm-dev)     # debian naming convention 'of-rtm<VERSION>'
+    versionNum="${projectDirName##of-rtm}"
     case "$versionNum" in
     ??)         # convert 2 digit version number to decimal delineated
         version=$(echo "$versionNum" | sed -e 's@\(.\)\(.\)@\1.\2@')
@@ -211,15 +211,15 @@ done
 
 
 # Save the essential bits of information
-# silently remove leading ~OpenFOAM/ (used in Foam::findEtcFile)
+# silently remove leading ~of-rtm/ (used in Foam::findEtcFile)
 nArgs=$#
-fileName="${1#~OpenFOAM/}"
+fileName="${1#~of-rtm/}"
 
 # Define the various places to be searched:
 unset dirList
 case "$mode" in
 *u*)  # user
-    userDir="$HOME/.${WM_PROJECT:-OpenFOAM}"
+    userDir="$HOME/.${WM_PROJECT:-of-rtm}"
     dirList="$dirList $userDir/$version $userDir"
     ;;
 esac
@@ -236,10 +236,10 @@ case "$mode" in
     if [ -n "$versionNum" ]
     then
         # debian packaging
-        dirList="$dirList $prefixDir/openfoam$versionNum/etc"
+        dirList="$dirList $prefixDir/of-rtm$versionNum/etc"
     else
         # standard packaging
-        dirList="$dirList $prefixDir/${WM_PROJECT:-OpenFOAM}-$version/etc"
+        dirList="$dirList $prefixDir/${WM_PROJECT:-of-rtm}-$version/etc"
     fi
     ;;
 esac

--- a/etc/bashrc
+++ b/etc/bashrc
@@ -31,7 +31,7 @@
 #
 #------------------------------------------------------------------------------
 
-export WM_PROJECT=OpenFOAM
+export WM_PROJECT=of-rtm
 export WM_PROJECT_VERSION=6
 
 ################################################################################
@@ -43,8 +43,8 @@ export WM_PROJECT_VERSION=6
 # Please set to the appropriate path if the default is not correct.
 #
 [ "$BASH" -o "$ZSH_NAME" ] && \
-# export FOAM_INST_DIR=$(cd $(dirname ${BASH_SOURCE:-$0})/../.. && pwd -P) || \
-export FOAM_INST_DIR=$HOME/$WM_PROJECT-$WM_PROJECT_VERSION
+export FOAM_INST_DIR=$(cd $(dirname ${BASH_SOURCE:-$0})/../.. && pwd -P) || \
+export FOAM_INST_DIR=$HOME/$WM_PROJECT
 # export FOAM_INST_DIR=~$WM_PROJECT
 # export FOAM_INST_DIR=/opt/$WM_PROJECT
 # export FOAM_INST_DIR=/usr/local/$WM_PROJECT
@@ -111,7 +111,7 @@ foamOldDirs="$WM_PROJECT_DIR $WM_THIRD_PARTY_DIR \
 # Location of installation
 # ~~~~~~~~~~~~~~~~~~~~~~~~
 export WM_PROJECT_INST_DIR=$FOAM_INST_DIR
-export WM_PROJECT_DIR=$WM_PROJECT_INST_DIR
+export WM_PROJECT_DIR=$WM_PROJECT_INST_DIR/$WM_PROJECT-$WM_PROJECT_VERSION
 
 # Location of third-party software
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -129,7 +129,7 @@ fi
 
 # Location of user files
 # ~~~~~~~~~~~~~~~~~~~~~~
-export WM_PROJECT_USER_DIR=$HOME/Programme/$WM_PROJECT-$WM_PROJECT_VERSION/$USER-$WM_PROJECT_VERSION
+export WM_PROJECT_USER_DIR=$HOME/$WM_PROJECT/$USER-$WM_PROJECT_VERSION
 
 # Source initialization functions
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/wmake/makefiles/general
+++ b/wmake/makefiles/general
@@ -61,10 +61,10 @@ OBJECTS_DIR     = $(MAKE_DIR)/$(WM_OPTIONS)
 SYS_INC         =
 SYS_LIBS        =
 
-PROJECT_INC     = -I$(LIB_SRC)/$(WM_PROJECT)/lnInclude \
+PROJECT_INC     = -I$(LIB_SRC)/OpenFOAM/lnInclude \
 		     -I$(LIB_SRC)/OSspecific/$(WM_OSTYPE)/lnInclude
 
-PROJECT_LIBS    = -l$(WM_PROJECT)
+PROJECT_LIBS    = -lOpenFOAM
 
 EXE_INC         =
 EXE_LIBS        =
@@ -83,7 +83,7 @@ LIB             = libNULL
 SO              = so
 
 # Project executable
-EXE             = $(WM_PROJECT).out
+EXE             = OpenFOAM.out
 
 # Standalone executable
 SEXE            = a.out

--- a/wmake/rules/linux64Clang/general
+++ b/wmake/rules/linux64Clang/general
@@ -1,6 +1,6 @@
 CPP        = cpp -traditional-cpp $(GFLAGS)
 
-PROJECT_LIBS = -l$(WM_PROJECT) -ldl
+PROJECT_LIBS = -lOpenFOAM -ldl
 
 include $(GENERAL_RULES)/standard
 

--- a/wmake/rules/linux64Gcc/general
+++ b/wmake/rules/linux64Gcc/general
@@ -1,6 +1,6 @@
 CPP        = cpp -traditional-cpp $(GFLAGS)
 
-PROJECT_LIBS = -l$(WM_PROJECT) -ldl
+PROJECT_LIBS = -lOpenFOAM -ldl
 
 include $(GENERAL_RULES)/standard
 

--- a/wmake/rules/linux64GccKNL/general
+++ b/wmake/rules/linux64GccKNL/general
@@ -1,6 +1,6 @@
 CPP        = cpp -traditional-cpp $(GFLAGS)
 
-PROJECT_LIBS = -l$(WM_PROJECT) -ldl
+PROJECT_LIBS = -lOpenFOAM -ldl
 
 include $(GENERAL_RULES)/standard
 

--- a/wmake/rules/linux64Icc/general
+++ b/wmake/rules/linux64Icc/general
@@ -1,6 +1,6 @@
 CPP        = /lib/cpp -traditional-cpp $(GFLAGS)
 
-PROJECT_LIBS = -l$(WM_PROJECT) -ldl
+PROJECT_LIBS = -lOpenFOAM -ldl
 
 include $(GENERAL_RULES)/standard
 

--- a/wmake/rules/linux64IccKNL/general
+++ b/wmake/rules/linux64IccKNL/general
@@ -1,6 +1,6 @@
 CPP        = /lib/cpp -traditional-cpp $(GFLAGS)
 
-PROJECT_LIBS = -l$(WM_PROJECT) -ldl
+PROJECT_LIBS = -lOpenFOAM -ldl
 
 include $(GENERAL_RULES)/standard
 

--- a/wmake/rules/linuxARM7Gcc/general
+++ b/wmake/rules/linuxARM7Gcc/general
@@ -1,7 +1,7 @@
 CPP        = cpp -traditional-cpp $(GFLAGS)
 LD         = ld
 
-PROJECT_LIBS = -l$(WM_PROJECT) -ldl
+PROJECT_LIBS = -lOpenFOAM -ldl
 
 include $(GENERAL_RULES)/standard
 

--- a/wmake/rules/linuxClang/general
+++ b/wmake/rules/linuxClang/general
@@ -1,7 +1,7 @@
 CPP        = cpp -traditional-cpp $(GFLAGS)
 LD         = ld -melf_i386
 
-PROJECT_LIBS = -l$(WM_PROJECT) -ldl
+PROJECT_LIBS = -lOpenFOAM -ldl
 
 include $(GENERAL_RULES)/standard
 

--- a/wmake/rules/linuxGcc/general
+++ b/wmake/rules/linuxGcc/general
@@ -1,7 +1,7 @@
 CPP        = cpp -traditional-cpp $(GFLAGS)
 LD         = ld -melf_i386
 
-PROJECT_LIBS = -l$(WM_PROJECT) -ldl
+PROJECT_LIBS = -lOpenFOAM -ldl
 
 include $(GENERAL_RULES)/standard
 

--- a/wmake/rules/linuxIA64Gcc/general
+++ b/wmake/rules/linuxIA64Gcc/general
@@ -1,6 +1,6 @@
 CPP        = cpp -traditional-cpp $(GFLAGS)
 
-PROJECT_LIBS = -l$(WM_PROJECT) -ldl
+PROJECT_LIBS = -lOpenFOAM -ldl
 
 include $(GENERAL_RULES)/standard
 

--- a/wmake/rules/linuxIcc/general
+++ b/wmake/rules/linuxIcc/general
@@ -1,7 +1,7 @@
 CPP        = /lib/cpp -traditional-cpp $(GFLAGS)
 LD         = ld -melf_i386
 
-PROJECT_LIBS = -l$(WM_PROJECT) -ldl
+PROJECT_LIBS = -lOpenFOAM -ldl
 
 include $(GENERAL_RULES)/standard
 

--- a/wmake/rules/linuxPPC64Gcc/general
+++ b/wmake/rules/linuxPPC64Gcc/general
@@ -1,7 +1,7 @@
 CPP        = cpp -traditional-cpp $(GFLAGS)
 LD         = ld -m elf64ppc
 
-PROJECT_LIBS = -l$(WM_PROJECT) -ldl
+PROJECT_LIBS = -lOpenFOAM -ldl
 
 include $(GENERAL_RULES)/standard
 

--- a/wmake/rules/linuxPPC64leGcc/general
+++ b/wmake/rules/linuxPPC64leGcc/general
@@ -1,7 +1,7 @@
 CPP        = cpp -traditional-cpp $(GFLAGS)
 LD         = ld -m elf64lppc
 
-PROJECT_LIBS = -l$(WM_PROJECT) -ldl
+PROJECT_LIBS = -lOpenFOAM -ldl
 
 include $(GENERAL_RULES)/standard
 

--- a/wmake/rules/solaris64Gcc/general
+++ b/wmake/rules/solaris64Gcc/general
@@ -1,7 +1,7 @@
 CPP        = /lib/cpp
 LD         = ld -64
 
-PROJECT_LIBS = -l$(WM_PROJECT) -lnsl -lsocket -L$(FOAM_LIBBIN)/dummy -lPstream
+PROJECT_LIBS = -lOpenFOAM -lnsl -lsocket -L$(FOAM_LIBBIN)/dummy -lPstream
 
 include $(GENERAL_RULES)/standard
 

--- a/wmake/rules/solarisGcc/general
+++ b/wmake/rules/solarisGcc/general
@@ -1,6 +1,6 @@
 CPP        = /usr/lib/cpp -undef
 
-PROJECT_LIBS = -l$(WM_PROJECT) -lnsl -lsocket -L$(FOAM_LIBBIN)/dummy -lPstream
+PROJECT_LIBS = -lOpenFOAM -lnsl -lsocket -L$(FOAM_LIBBIN)/dummy -lPstream
 
 include $(GENERAL_RULES)/standard
 

--- a/wmake/wmakeLnIncludeAll
+++ b/wmake/wmakeLnIncludeAll
@@ -119,7 +119,7 @@ then
 
     # shellcheck disable=SC2016
     includeDirs="
-        $WM_PROJECT_DIR/src/$WM_PROJECT
+        $WM_PROJECT_DIR/src/OpenFOAM
         $WM_PROJECT_DIR/src/OSspecific/$WM_OSTYPE
         $(grep -e '-I.*lnInclude' $MakeDir/options |
         sed -e 's%-I\([.$(a-zA-Z0-9_)/]*\)lnInclude.*%\1%' -e 's/$(\(.*\))/$\1/')"


### PR DESCRIPTION
Content of this merge:

- bashrc is reverted to the original version but WM_PROJECT is renamed to of-rtm to distinguish between our release and the official one
- build related files in bin/ and wmake/ directories contain patches to make compilation work for renamed WM_PROJECT